### PR TITLE
Fixed `withLocallyShiftedOptic` for rotated optics

### DIFF
--- a/batoid/optic.py
+++ b/batoid/optic.py
@@ -1458,7 +1458,11 @@ class CompoundOptic(Optic):
             Optic with shifted subitem.
         """
         # Just apply the rotated global shift.
-        return self.withGloballyShiftedOptic(name, self.coordSys.rot@shift)
+        name = self._names.get(name, name)
+        if name not in self.itemDict:
+            raise ValueError("Optic {} not found".format(name))
+        coordSys = self.itemDict[name].coordSys
+        return self.withGloballyShiftedOptic(name, coordSys.rot@shift)
 
     def withGlobalRotation(self, rot, rotCenter=None, coordSys=None):
         """Return a new `CompoundOptic` with its coordinate system rotated.

--- a/tests/test_Optic.py
+++ b/tests/test_Optic.py
@@ -619,6 +619,7 @@ if __name__ == '__main__':
     test_shift()
     test_rotXYZ_parsing()
     test_rotation()
+    test_local_shift_with_rotation()
     test_ne()
     test_name()
     test_cbp_rotation()

--- a/tests/test_Optic.py
+++ b/tests/test_Optic.py
@@ -247,6 +247,46 @@ def test_rotation():
 
 
 @timer
+def test_local_shift_with_rotation():
+    # Load HSC for testing
+    telescope = batoid.Optic.fromYaml("HSC.yaml")
+
+    # Rotate the entire telescope
+    rotFull = telescope.withLocalRotation(batoid.RotX(np.pi/2))
+
+    # Make global and local shifts
+    rotFullGlobalShift = rotFull.withGlobalShift([1, 3, 5])
+    rotFullLocalShift = rotFull.withLocalShift([1, 5, -3])
+
+    # Check these coordinate systems are the same
+    assert np.allclose(
+        rotFullGlobalShift.coordSys.origin,
+        rotFullLocalShift.coordSys.origin,
+    )
+    assert np.allclose(
+        rotFullGlobalShift.coordSys.rot,
+        rotFullLocalShift.coordSys.rot,
+    )
+
+    # Now rotate a subitem
+    rotCAM = telescope.withLocallyRotatedOptic("CAM", batoid.RotY(np.pi/2))
+
+    # Make global and local shifts
+    rotCamGlobalShift = rotCAM.withGloballyShiftedOptic("CAM", [3, 5, 1])
+    rotCamLocalShift = rotCAM.withLocallyShiftedOptic("CAM", [-1, 5, 3])
+
+    # Check these coordinate systems are the same
+    assert np.allclose(
+        rotCamGlobalShift["CAM"].coordSys.origin,
+        rotCamLocalShift["CAM"].coordSys.origin,
+    )
+    assert np.allclose(
+        rotCamGlobalShift["CAM"].coordSys.rot,
+        rotCamLocalShift["CAM"].coordSys.rot,
+    )
+
+
+@timer
 def test_ne():
     objs = [
         batoid.Mirror(batoid.Plane()),


### PR DESCRIPTION
Fixed bug where `CompoundOptic.withLocallyShiftedOptic` used the rotation of the top-level optic rather than the rotation of the subitem. I also wrote a test that compares global and local shifts for rotated optics.